### PR TITLE
Restore state

### DIFF
--- a/geoptics/guis/qt/__init__.py
+++ b/geoptics/guis/qt/__init__.py
@@ -125,7 +125,13 @@ Whether advantages dominate is not clear at the moment, but here it is.
 Forks are welcome.
 """
 
-import sip
+try:
+	# new location for sip
+	# https://www.riverbankcomputing.com/static/Docs/PyQt5/incompatibilities.html#pyqt-v5-11
+	from PyQt5 import sip
+except ImportError:
+	import sip
+
 sip.setapi('QVariant', 2)
 # this one is not used yet
 # but it will ensure that QString are not used (deprecated)

--- a/geoptics/guis/qt/main.py
+++ b/geoptics/guis/qt/main.py
@@ -389,7 +389,9 @@ class Gui(QMainWindow):
 		settings.beginGroup("MainWindow")
 		self.resize(settings.value("size", QSize(400, 400), type=QSize))
 		self.move(settings.value("pos", QPoint(10, 10), type=QPoint))
-		self.restoreState(settings.value("MainwindowState"))
+		old_settings = settings.value("MainwindowState")
+		if old_settings:
+			self.restoreState(old_settings)
 		settings.endGroup()
 	
 	def select_all(self):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36, flake8, rst-lint, docs
+envlist = py36, py37, flake8, rst-lint, docs
 
 [testenv]
 # changedir = {envtmpdir}


### PR DESCRIPTION
For a new user, there is no configuration to restore.
This PR should fix issue #3.
Incidently, python3.7 was added to the list of tox environments
And `sip` has been moved to `PyQt5` in recent versions
https://www.riverbankcomputing.com/static/Docs/PyQt5/incompatibilities.html#pyqt-v5-11
The proposed PR still works on older systems (tested with `PyQt 5.10.1`).