### PR TITLE
prepare bump2version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,16 @@
+[bumpversion]
+current_version = 0.20
+parse = (?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?
+serialize = 
+	{major}.{minor}.{patch}
+	{major}.{minor}
+
+[bumpversion:file:geoptics/__init__.py]
+
+[bumpversion:file:NEWS]
+search = Changes since {current_version}
+replace = Changes since {new_version}
+	
+	
+	Changes in {new_version}
+

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+Changes since 0.20
+
+- [new] define editor defaults in .editorconfig (https://EditorConfig.org)
+- [change] migration from mercurial to git revsion system
+- [change] use decorators instead of multiple inheritance
+           for graphical counterpart
+- [bugfix] restore only existing configurations (important for new users)
+
 Changes in 0.20
 
 - [new] use tox for tests

--- a/geoptics/__init__.py
+++ b/geoptics/__init__.py
@@ -8,7 +8,11 @@
 
 """
 
-__version__ = "0.19"
+# keep this at the top (simpler .bumpversion.cfg)
+# and do not modify directly; use
+# bump2version minor
+# https://github.com/c4urself/bump2version
+__version__ = "0.20"
 
 
 import logging


### PR DESCRIPTION
Prepare to use [bump2version](https://github.com/c4urself/bump2version).

Dry run: 
```bash
bump2version --allow-dirty --dry-run --verbose minor
```

Changes minor version number: 
```bash
bump2version minor
```